### PR TITLE
Multiple Bug Fixes Preventing Workflow Completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BinSanity v0.1.1
+# BinSanity v0.1.2
 
 Program implements Affinity Propagation to cluster contigs into putative genomes. BinSanity uses contig coverage as an input, while BinSanity-refine incorporates tetranucleotide frequencies, GC content, and an optional input of coverage. All relevant scripts to produce inputs for BinSanity are provided here.
 

--- a/Utils/contig-coverage-bam.py
+++ b/Utils/contig-coverage-bam.py
@@ -26,10 +26,10 @@ def extract_from_bam(bam_results):
             sys.stdout.write("\rNumber of record processed for coverage: %i" % count)
             sys.stdout.flush()
     return out_dict
-    
-    
+
+
 def create_cov_file(length_dictionary,bedtools_dict,outname):
-    print 
+    print
     """
     ---------------------------------------------------------
                     Building Coverage File
@@ -44,6 +44,8 @@ def create_cov_file(length_dictionary,bedtools_dict,outname):
         get_length = length_dictionary[contig]
         contig_dict.setdefault("length",str(get_length))
         average_coverage = contig_dict.get('cov_mean')
+        if average_coverage is None:
+            average_coverage = '0'
         average_coverage=str(average_coverage)
         contigs.append(contig)
         coverage.append(average_coverage)
@@ -54,7 +56,7 @@ def create_cov_file(length_dictionary,bedtools_dict,outname):
     y = zip(contigs,coverage,length)
     with open(outname, 'w') as file:
         file.writelines('\t'.join(i) + '\n' for i in y)
-        
+
 def find_contig_length(fastafile):
     len_dict = {}
     count = 0
@@ -64,12 +66,12 @@ def find_contig_length(fastafile):
         sys.stdout.write("\rNumber of sequences Processed for length: %i" % count)
         sys.stdout.flush()
     return len_dict
-                
-        
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog='contig-coverage-bam.py', usage='%(prog)s -b Bam File -r Fasta File -o Output File')
     parser.add_argument("-f", dest="fastafile", help="Fasta File")
-    parser.add_argument("-b", dest="bamfiles", help="BAM file")   
+    parser.add_argument("-b", dest="bamfiles", help="BAM file")
     parser.add_argument("-o",dest="outfile",help="outfile name (e.g file.coverage)")
     args = parser.parse_args()
     signal(SIGPIPE,SIG_DFL)
@@ -77,16 +79,16 @@ if __name__ == "__main__":
     ---------------------------------------------------------
             Finding Length information for each Contig
     ---------------------------------------------------------
-    
+
     """
     x =find_contig_length(args.fastafile)
     print """
-    
-    
+
+
     ---------------------------------------------------------
      Extracting Coverage Information from provided BAM file
     ---------------------------------------------------------
-    
+
     """
     y = extract_from_bam(args.bamfiles)
     create_cov_file(x,y,args.outfile)

--- a/Utils/cov-combine.py
+++ b/Utils/cov-combine.py
@@ -20,7 +20,7 @@ def get_contigs(c):
             if name not in all_contigs:
                 all_contigs.append(name)
     return all_contigs
-    
+
 
 def get_coverage(a,b,c):
     coverage_log_all = {}
@@ -38,7 +38,7 @@ def get_coverage(a,b,c):
         for n in cov:
             log = np.log10((float(n))+1)
             coverage_log.append(str(log))
-    
+
         data = zip(contig,coverage_log)
         data = dict(data)
         for name in all_:
@@ -49,19 +49,19 @@ def get_coverage(a,b,c):
                     coverage_log_all.setdefault(name, [])
                     coverage_log_all[name].append('0')
         for key in data.viewkeys():
-            if key in all_: 
+            if key in all_:
                 if key in coverage_log_all:
                     coverage_log_all[key].append(data[key])
                 elif key not in coverage_log_all:
                     coverage_log_all.setdefault(key, [])
                     coverage_log_all[key].append(data[key])
 
-                
+
     out = open(str(b), 'w')
     for key, value in coverage_log_all.iteritems():
         out.write('%s\t%s\n' % (key,'\t'.join(value)))
     out.close()
-    
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='cov-combine.py', usage='%(prog)s -o Output File')
     parser.add_argument("-o", dest="inputoutput", help="Specify the output file")
@@ -72,7 +72,7 @@ if __name__ == '__main__':
     if args.inputCoverage is None:
         parser.error('-c suffic linking coverage profiles needed')
     else:
-        time = time.time()
+        startTime = time.time()
         print"""
         ---------------------------------------------------------------------
         """
@@ -81,4 +81,4 @@ if __name__ == '__main__':
         print ("""
         --------------------------------------------------------------------
                  Finished combined coverage profiles in %s seconds
-        ____________________________________________________________________""" % (time.time() - time))
+        ____________________________________________________________________""" % (time.time() - startTime))


### PR DESCRIPTION
The workflow given in the README did not work if using multiple BAM files because contig-coverage-bam.py output "None" if a contig had zero coverage which broke cov-combine.py. Replacing "None" with "0" in coverage files generated by contig-coverage-bam.py rectified the issue and properly accounts for zero coverage contigs. Second, Line 75 in cov-combine.py shadowed a built-in Python name and would thus fail to execute. Changing the variable name fixed the bug. Version number in README changed to reflect bug fixes. IDE PyCharm eliminated invisible whitespace present on many lines.