### PR TITLE
Make BinSanity compatible with both Python2 and Python3

### DIFF
--- a/bin/Binsanity
+++ b/bin/Binsanity
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+from __future__ import print_function, division
+
 import os, sys, time, argparse,shutil
 import numpy as np
 from Bio import SeqIO
@@ -37,7 +39,7 @@ def cov_array(a,path,file_name,size):
     for record in SeqIO.parse(os.path.join(path, file_name), "fasta"):
         count = count + 1
         if len(record.seq) >= int(size):
-            if record.id in a.keys():
+            if record.id in a:
                 data = a[record.id]
                 names.append(data[0])
                 data.remove(data[0])
@@ -47,9 +49,9 @@ def cov_array(a,path,file_name,size):
                     cov_array = np.vstack((cov_array, temparray))
                 if c == 0:
                     cov_array = np.fromstring(line, dtype=float, sep=' ')
-                    c += 1 
-    print "          %s" % (cov_array.shape,)
-    return cov_array, names  
+                    c += 1
+    print("          %s" % (cov_array.shape,))
+    return cov_array, names
 ################################################################################################################
 def affinity_propagation(array,names,file_name,damping,iterations,convergence,preference,path,output_directory,outname):
     """Uses affinity propagation to make putative bins"""
@@ -57,18 +59,18 @@ def affinity_propagation(array,names,file_name,damping,iterations,convergence,pr
     outfile_data = {}
     i = 0
     while i < len(names):
-        if apclust[i] in outfile_data.keys():
+        if apclust[i] in outfile_data:
             outfile_data[apclust[i]].append(names[i])
-        if apclust[i] not in outfile_data.keys():
+        if apclust[i] not in outfile_data:
             outfile_data[apclust[i]] = [names[i]]
         i += 1
     if outname is None:
-	out_name = file_name.rsplit(".",1)[0]+"_Bin"
+        out_name = file_name.rsplit(".",1)[0]+"_Bin"
     else:
-	out_name = outname+"_Bin"
-    with open(os.path.join(path,file_name),"r") as input2_file: 
-        fasta_dict = create_fasta_dict(input2_file)                
-        count = 0                
+        out_name = outname+"_Bin"
+    with open(os.path.join(path,file_name),"r") as input2_file:
+        fasta_dict = create_fasta_dict(input2_file)
+        count = 0
         for k in outfile_data:
             if len(outfile_data[k]) >= 5:
                 output_file = open(os.path.join(output_directory,str(out_name)+"-%s.fna" % (k)), "w")
@@ -91,14 +93,14 @@ def affinity_propagation(array,names,file_name,damping,iterations,convergence,pr
             if os.path.isfile(os.path.join(output_directory,'unclustered.fna')) is True:
                 contig_number = 0
                 for record in SeqIO.parse(os.path.join(output_directory,'unclustered.fna'),"fasta"):
-                        contig_number +=1
+                    contig_number +=1
                 if contig_number < 2:
-                        os.remove(os.path.join(output_directory,'unclustered.fna'))
-            print "          Cluster "+str(k)+": "+str(len(outfile_data[k]))
-        print ("""          Total Number of Bins: %i""" % count)
-    
-     
-########################################################################################     
+                    os.remove(os.path.join(output_directory,'unclustered.fna'))
+            print("          Cluster "+str(k)+": "+str(len(outfile_data[k])))
+        print(("""          Total Number of Bins: %i""" % count))
+
+
+########################################################################################
 class Logger(object):
     def __init__(self,logfile,location):
         self.terminal = sys.stdout
@@ -106,10 +108,10 @@ class Logger(object):
 
     def write(self, message):
         self.terminal.write(message)
-        self.log.write(message)  
+        self.log.write(message)
 
     def flush(self):
-        pass  
+        pass
 
 ###################################################################
 
@@ -123,22 +125,22 @@ if __name__ == '__main__':
     **  of contigs in putative bins.                                           **
     **                                                                         **
     **  NOTE: BinSanity becomes highly memory intensive at 100,000 contigs or  **
-    **  above. If you have greater than this number of contigs we recommend    **  
+    **  above. If you have greater than this number of contigs we recommend    **
     **  trying the beta-version for our script binsanity-lc.                   **
     *****************************************************************************
     """,usage='%(prog)s -f [/path/to/fasta] -l [fastafile] -c [coverage file]',formatter_class=RawTextHelpFormatter)
     parser.add_argument("-c", dest="inputCovFile", help="""Specify a Coverage File
     """)
-    parser.add_argument("-f", dest="inputContigFiles", help="""Specify directory 
+    parser.add_argument("-f", dest="inputContigFiles", help="""Specify directory
     containing your contigs
     """)
     parser.add_argument("-p", type=float, dest="preference", default=-3, help="""
-    Specify a preference (default is -3) 
-    
-    Note: decreasing the preference leads to more lumping, 
-    increasing will lead to more splitting. If your range 
+    Specify a preference (default is -3)
+
+    Note: decreasing the preference leads to more lumping,
+    increasing will lead to more splitting. If your range
     of coverages are low you will want to decrease the preference,
-    if you have 10 or less replicates increasing the preference could 
+    if you have 10 or less replicates increasing the preference could
     benefit you.""")
     parser.add_argument("-m", type=int, dest="maxiter", default=4000, help="""
     Specify a max number of iterations [default is 2000]""")
@@ -153,7 +155,7 @@ if __name__ == '__main__':
     parser.add_argument("-x",dest="ContigSize", type=int, default=1000,help="""
     Specify the contig size cut-off [Default 1000 bp]""")
     parser.add_argument("-o",dest="outputdir", default="BINSANITY-RESULTS", help="""
-    Give a name to the directory BinSanity results will be output in 
+    Give a name to the directory BinSanity results will be output in
     [Default is 'BINSANITY-RESULTS']""")
     parser.add_argument("--outPrefix",dest="outname",default=None,help="""
     Sepcify what prefix you want appended to final Bins {optional}""")
@@ -163,52 +165,52 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     if len(sys.argv)<3:
-        print parser.print_help()
+        print(parser.print_help())
     elif args.inputCovFile is None:
         if (args.inputContigFiles is None) and (args.fastafile is None):
             parser.print_help()
     elif (args.inputCovFile is None):
-        print "Please indicate -c coverage file"
+        print("Please indicate -c coverage file")
     elif args.inputContigFiles is None:
-        print "Please indicate -f directory containing your contigs"
+        print("Please indicate -f directory containing your contigs")
     elif args.inputContigFiles and not args.fastafile:
         parser.error('-l Need to identify file to be clustered')
     else:
-	if os.path.isdir(str(args.outputdir)) is False:
-		os.mkdir(args.outputdir)
+        if os.path.isdir(str(args.outputdir)) is False:
+            os.mkdir(args.outputdir)
         start_time = time.time()
         sys.stdout = Logger(args.logfile,args.outputdir)
-        print """
+        print("""
         ******************************************************
         **********************BinSanity***********************
         |____________________________________________________|
         |                                                    |
         |             Computing Coverage Array               |
         |____________________________________________________|
-        """
-        print "          Preference: " + str(args.preference)
-        print "          Maximum Iterations: " + str(args.maxiter)
-        print "          Convergence Iterations: " + str(args.conviter)
-        print "          Contig Cut-Off: " + str(args.ContigSize)
-        print "          Damping Factor: " + str(args.damp)
-        print "          Coverage File: " + str(args.inputCovFile)
-        print "          Fasta File: " + str(args.fastafile)
-        print "          Output directory: " + str(args.outputdir)
-	print "          logfile: " + str(args.logfile)
-        
-        
+        """)
+        print("          Preference: " + str(args.preference))
+        print("          Maximum Iterations: " + str(args.maxiter))
+        print("          Convergence Iterations: " + str(args.conviter))
+        print("          Contig Cut-Off: " + str(args.ContigSize))
+        print("          Damping Factor: " + str(args.damp))
+        print("          Coverage File: " + str(args.inputCovFile))
+        print("          Fasta File: " + str(args.fastafile))
+        print("          Output directory: " + str(args.outputdir))
+        print("          logfile: " + str(args.logfile))
+
+
         val1, val2 = cov_array((get_cov_data(args.inputCovFile)), args.inputContigFiles, args.fastafile,args.ContigSize)
 
-        print """
+        print("""
          ______________________________________________________
         |                                                      |
         |                 Clustering Contigs                   |
         |______________________________________________________|
 
-        """
+        """)
         affinity_propagation(val1, val2, args.fastafile, args.damp, args.maxiter, args.conviter, args.preference,args.inputContigFiles,args.outputdir,args.outname)
-  
-        print
+
+        print()
         """
          *|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*
          _____________________________________________________
@@ -217,9 +219,9 @@ if __name__ == '__main__':
         |_____________________________________________________|
         """
 
-        print("""
+        print(("""
          _____________________________________________________
 
                        Putative Bins Computed
                        in %s seconds
-         _____________________________________________________""" % (time.time() - start_time))
+         _____________________________________________________""" % (time.time() - start_time)))

--- a/bin/Binsanity-profile
+++ b/bin/Binsanity-profile
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from __future__ import print_function, division
 
 from Bio import SeqIO
 import sys, subprocess, argparse
@@ -21,38 +22,38 @@ def format_for_feature(inputfile,mapfile,outputpath):
             handle = open(os.path.join(outputpath,str(outname)+".saf"),'w')
             handle.write('GeneID   Chr     Start   End     Strand\n')
             for record in SeqIO.parse(inputfile,'fasta'):
-                    seqLen = len(record.seq)
-                    start, stop = 1, seqLen
-                    geneId, Chr = str(record.id), str(record.id)
-                    outLine = [geneId, Chr, str(start), str(stop), '+']
-                    outLine = '\t'.join(outLine)
-                    handle.write(outLine + "\n")
+                seqLen = len(record.seq)
+                start, stop = 1, seqLen
+                geneId, Chr = str(record.id), str(record.id)
+                outLine = [geneId, Chr, str(start), str(stop), '+']
+                outLine = '\t'.join(outLine)
+                handle.write(outLine + "\n")
 def feature_counts(mapfile,outputdir,threads):
     for file_ in os.listdir(mapfile):
-	if file_.endswith('.bam'):
-        	outname=str(file_).lstrip('.bam')
-        	mapfile_file = os.path.join(mapfile,file_)
-        	subprocess.call(["featureCounts","-M","-O", "-F", "SAF","-T",str(threads),"-a", os.path.join(outputdir,str(outname)+".saf"),"-o", os.path.join(outputdir,str(outname)+".readcounts"),str(mapfile_file)],stdout=subprocess.PIPE)
+        if file_.endswith('.bam'):
+            outname=str(file_).lstrip('.bam')
+            mapfile_file = os.path.join(mapfile,file_)
+            subprocess.call(["featureCounts","-M","-O", "-F", "SAF","-T",str(threads),"-a", os.path.join(outputdir,str(outname)+".saf"),"-o", os.path.join(outputdir,str(outname)+".readcounts"),str(mapfile_file)],stdout=subprocess.PIPE)
 
 def make_coverage(ids,outfile,outputdir):
-    cov_data = {}    
+    cov_data = {}
     for line in open(str(ids), "r"):
-    	line = line.rstrip()
-	cov_data[line] = []
+        line = line.rstrip()
+        cov_data[line] = []
     count_filenames = [f for f in os.listdir(outputdir) if f.endswith('.readcounts')]
     for i in count_filenames:
         for line in open(os.path.join(outputdir,i), "r"):
-                if line[0] != "#" or line[:6] != "Geneid":
-                        line = line.rstrip()
-                        data = line.split()
-                        try:
-                            length = len(cov_data[data[0]])
-                            if length == 0:
-                                cov_data[data[0]] = [data[5], data[6]]
-                            if length > 0:
-                                cov_data[data[0]].append(data[6])
-                        except KeyError:
-                                continue
+            if line[0] != "#" or line[:6] != "Geneid":
+                line = line.rstrip()
+                data = line.split()
+                try:
+                    length = len(cov_data[data[0]])
+                    if length == 0:
+                        cov_data[data[0]] = [data[5], data[6]]
+                    if length > 0:
+                        cov_data[data[0]].append(data[6])
+                except KeyError:
+                    continue
     out1 = open(str(outfile)+".cov", "w")
 
     for k in cov_data:
@@ -68,14 +69,14 @@ def get_log(file_,outfile):
             list_[num_] = np.log10(((float(list_[num_])))+1)
     pd = pandas.DataFrame(cov_file)
     pd.to_csv(outfile,sep="\t",index=False,header=False)
-    
+
 def get_multiple(file_,outfile,num):
     cov_file = list(csv.reader(open(str(file_), 'rb'), delimiter='\t'))
     for list_ in cov_file:
         for num_ in range(1,len(list_)):
             list_[num_] = float(list_[num_])*int(num)
     pd = pandas.DataFrame(cov_file)
-    pd.to_csv(outfile,sep="\t",index=False,header=False)  
+    pd.to_csv(outfile,sep="\t",index=False,header=False)
 
 def get_squareroot(file_,outfile):
     cov_file = list(csv.reader(open(str(file_), 'rb'), delimiter='\t'))
@@ -90,7 +91,7 @@ def get_100x_log(file_,outfile):
         for num_ in range(1,len(list_)):
             list_[num_] = np.log10((float(list_[num_])*int(100))+1)
     pd = pandas.DataFrame(cov_file)
-    pd.to_csv(outfile,sep="\t",index=False,header=False)     
+    pd.to_csv(outfile,sep="\t",index=False,header=False)
 ########################################################################################
 class Logger(object):
     def __init__(self,logfile,location):
@@ -110,16 +111,16 @@ if __name__ == "__main__":
     ******************************BinSanity********************************
     **                                                                   **
     **  Binsanity-profile is used to generate coverage files for         **
-    **  input to BinSanity. This uses Featurecounts to generate a        **  
+    **  input to BinSanity. This uses Featurecounts to generate a        **
     **  a coverage profile and transforms data for input into Binsanity, **
     **  Binsanity-refine, and Binsanity-wf                               **
-    **                                                                   **  
+    **                                                                   **
     ***********************************************************************
-    ***********************************************************************""",formatter_class=RawTextHelpFormatter)    
+    ***********************************************************************""",formatter_class=RawTextHelpFormatter)
     parser.add_argument("-i", dest="inputFasta", help="Specify fasta file being profiled")
     parser.add_argument("-s", dest="inputMapLoc", help="""
     identify location of BAM files
-    BAM files should be indexed and sorted""") 
+    BAM files should be indexed and sorted""")
     parser.add_argument("--ids",dest="inputIds",help="""
     Identify file containing contig ids""")
     parser.add_argument("-c",dest="outCov",help="""
@@ -133,69 +134,69 @@ if __name__ == "__main__":
     X10 --> Multiplication by 10
     X100 --> Multiplication by 100
     SQR --> Square root
-    We recommend using a scaled log transformation for initial testing. 
+    We recommend using a scaled log transformation for initial testing.
     Other transformations can be useful on a case by case basis""")
     parser.add_argument('-T',dest='Threads',default=1,type=int,help="Specify Number of Threads For Feature Counts [Default: 1]")
     parser.add_argument('-o',dest="outDirectory",default=".",help="Specify directory for output files to be deposited [Default: Working Directory]")
     parser.add_argument('--version', action='version', version='%(prog)s v0.2.8')
-    args=parser.parse_args()  
+    args=parser.parse_args()
     if len(sys.argv)<3:
         parser.print_help()
     elif args.inputIds is None:
-        print "Need to identify file with contig ids `--ids`"
+        print("Need to identify file with contig ids `--ids`")
     elif args.inputFasta and args.inputIds is None:
-        print "Need to identify tab delimited file containing contig ids using '--ids' and fasta file using '-i'"
+        print("Need to identify tab delimited file containing contig ids using '--ids' and fasta file using '-i'")
     elif args.inputFasta and args.inputMapLoc is None:
-        print "Need to identify fasta file using '-i' and directory containing SAM/BAM files using '-s'."
+        print("Need to identify fasta file using '-i' and directory containing SAM/BAM files using '-s'.")
     elif args.inputFasta and args.outCov is None:
-        print "Need to identify fasta file using '-i' and output file for coverage profile using '-c'."        
+        print("Need to identify fasta file using '-i' and output file for coverage profile using '-c'.")
     elif args.inputFasta is None:
-        print "Need to identify fasta file using '-i'."
+        print("Need to identify fasta file using '-i'.")
     elif args.outCov is None:
-        print "Need to identify the output file using '-c'"
+        print("Need to identify the output file using '-c'")
     elif args.inputIds is None:
-        print "Need to identify tab delimited file containing contig ids using '--ids'"
+        print("Need to identify tab delimited file containing contig ids using '--ids'")
     elif args.inputMapLoc is None:
-        print "Need to identify directory containing SAM files using '-s'"
+        print("Need to identify directory containing SAM files using '-s'")
 ###########################################
     else:
-	if args.outDirectory is not ".":
-		if os.path.exists(args.outDirectory) is False:
-			os.mkdir(args.outDirectory)
-#	sys.stdout = Logger('Binsanity-Profile.log', args.outDirectory)
+        if args.outDirectory is not ".":
+            if os.path.exists(args.outDirectory) is False:
+                os.mkdir(args.outDirectory)
+#       sys.stdout = Logger('Binsanity-Profile.log', args.outDirectory)
         format_for_feature(args.inputFasta,args.inputMapLoc,args.outDirectory)
-	        
+
         print("""
         ******************************************************
                     Contigs formated to generate counts
         ******************************************************
         """)
         feature_counts(args.inputMapLoc,args.outDirectory,args.Threads)
-        
+
         make_coverage(args.inputIds,args.outCov,args.outDirectory)
 ###########################################
         x = os.path.join(args.outCov+".cov")
         if args.transform =="scale":
             get_100x_log(x,x+".x100.lognorm")
         elif args.transform == "log":
-            print "Transforming your combined coverage profile"
+            print("Transforming your combined coverage profile")
             get_log(x, x+".lognorm")
         elif args.transform =="X5":
-            print "Transforming your combined coverage profile"            
+            print("Transforming your combined coverage profile")
             get_multiple(x,x+".x5", int(5))
         elif args.transform =="X10":
-            print "Transforming your combined coverage profile"            
+            print("Transforming your combined coverage profile")
             get_multiple(x,x+".x10", int(10))
         elif args.transform =="X100":
-            print "Transforming your combined coverage profile"
-            get_multiple(x,x+".x100", int(100))       
+            print("Transforming your combined coverage profile")
+            get_multiple(x,x+".x100", int(100))
         elif args.transform =="SQR":
-            print "Transforming your combined coverage profile"            
+            print("Transforming your combined coverage profile")
             get_squareroot(x, x+".sqrt")
-        print """
-        
+        print("""
+
         ********************************************************
                         Coverage profile produced
         ********************************************************
-        
-        """
+
+        """)

--- a/bin/Binsanity-refine
+++ b/bin/Binsanity-refine
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+from __future__ import print_function, division
+from builtins import itervalues
 
 import collections
 import os, sys, time, argparse
@@ -28,20 +30,20 @@ __email__ = "egraham147@gmail.com"
 def GC_Fasta_file(b,name,outdir):
     """Makes a tab-delimeted output indicating the GC count associated with each contig"""
     GC_dict = {}
-    input_file = open(os.path.join(b,name), 'r') 
+    input_file = open(os.path.join(b,name), 'r')
     output_file = open(os.path.join(outdir,'GC_count.txt'),'w')
     output_file.write("%s\t%s\n" % ('contig','GC'))
     for cur_record in SeqIO.parse(input_file, "fasta") :
-        gene_name = cur_record.id 
+        gene_name = cur_record.id
         GC_percent = float(GC(cur_record.seq))
         GC_dict.setdefault(gene_name,[])
-        GC_dict[gene_name].append(GC_percent) 
+        GC_dict[gene_name].append(GC_percent)
         output_line = '%s\t%i\n' % \
-        (gene_name, GC_percent) 
+        (gene_name, GC_percent)
         output_file.write(output_line)
 
-        
-    output_file.close() 
+
+    output_file.close()
     input_file.close()
 ###########################Get tetramer frequencies#####################################
 
@@ -52,7 +54,7 @@ def kmer_list(dna, k):
     dna_edit = Seq(dna,IUPAC.unambiguous_dna)
     reverse_complement = (dna_edit).reverse_complement()
     dna_edit = str(dna_edit)
-    reverse_complement = str(reverse_complement)	
+    reverse_complement = str(reverse_complement)
     for x in range(len(dna_edit)+1-k):
         result.append(dna_edit[x:x+k])
     for x in range(len(reverse_complement)+1-k):
@@ -67,7 +69,7 @@ def kmer_counts(kmer,b,name):
         id_=str(record.id)
         seq = str(record.seq)
         length = len(seq)
-        tetra = kmer_list(seq,kmer)           
+        tetra = kmer_list(seq,kmer)
         c = collections.Counter(tetra)
         c = dict(c)
         val = list(c.values())
@@ -75,20 +77,20 @@ def kmer_counts(kmer,b,name):
         for freq in val:
             freq= (float(freq)/float(length))
             val_edit.append(freq)
-    
+
         keys = []
         for key in c:
             keys.append(str(key))
-        c_edit = dict(zip(keys,val_edit))
+        c_edit = dict(list(zip(keys,val_edit)))
         kmer_dict.setdefault(str(id_),[])
         kmer_dict[str(id_)].append(c_edit)
     return kmer_dict
-    
+
 def output(a,outdir,kmer):
     """Builds tab-delimeted file based on dictionary of tetramers"""
-    topleft = 'contig' 
+    topleft = 'contig'
     headers = sorted(set(key
-                        for row in a.values()
+                        for row in list(a.values())
                         for key in row[0]))
     writer = csv.writer(open(os.path.join(outdir,"%smer-frequencies.txt" % str(kmer)),'wb'), delimiter='\t')
     writer.writerow([topleft] + headers)
@@ -103,9 +105,9 @@ def get_contigs(c,outdir,kmer):
     dataframe =pandas.read_csv(GC,sep="\t",index_col=0,header=None)
     dataframe = dataframe.drop('contig')
     dataframe = dataframe.apply(pandas.to_numeric)
-    print dataframe.head()
+    print(dataframe.head())
     dataframe *= 100
-    dataframe +=1  
+    dataframe +=1
     dataframe = np.log10(dataframe)
     tetra = open(os.path.join(outdir,'%smer-frequencies.txt'%(str(kmer))),"r")
     dataframe2=pandas.read_csv(tetra,sep="\t",index_col=0,header=None)
@@ -126,7 +128,7 @@ def get_contigs(c,outdir,kmer):
     result.to_csv(path_or_buf=str(os.path.join(outdir,"kmer-GC-out.txt")),header=None,sep ="\t")
 
 
-##########################Run AP for refinement##############################    
+##########################Run AP for refinement##############################
 def create_fasta_dict(fastafile):
     """makes dictionary using fasta files to be binned"""
     fasta_dict = {}
@@ -153,7 +155,7 @@ def cov_array(a,b,name,size):
     cov_array = []
     for record in SeqIO.parse(os.path.join(b,name), "fasta"):
         if len(record.seq) >= int(size):
-            if record.id in a.keys():
+            if record.id in a:
                 data = a[record.id]
                 names.append(data[0])
                 data.remove(data[0])
@@ -164,27 +166,27 @@ def cov_array(a,b,name,size):
                 if c == 0:
                     cov_array = np.fromstring(line, dtype=float, sep=' ')
                     c += 1
-    print "          %s" % (cov_array.shape,)
-    return cov_array, names    
+    print("          %s" % (cov_array.shape,))
+    return cov_array, names
 
 def affinity_propagation(array,names,file_name,damping,iterations,convergence,preference,path,output_directory,outname):
-    """Uses affinity propagation to make putative bins"""    
+    """Uses affinity propagation to make putative bins"""
     apclust = AffinityPropagation(damping=float(damping), max_iter=int(iterations), convergence_iter=int(convergence), copy=True, preference=int(preference), affinity='euclidean', verbose=False).fit_predict(array)
     outfile_data = {}
     i = 0
     while i < len(names):
-        if apclust[i] in outfile_data.keys():
+        if apclust[i] in outfile_data:
             outfile_data[apclust[i]].append(names[i])
-        if apclust[i] not in outfile_data.keys():
+        if apclust[i] not in outfile_data:
             outfile_data[apclust[i]] = [names[i]]
         i += 1
     if outname is None:
-    	out_name = file_name.rsplit(".",1)[0]+"_Bin"
+        out_name = file_name.rsplit(".",1)[0]+"_Bin"
     else:
         out_name = outname+"_Bin"
-    with open(os.path.join(path,file_name),"r") as input2_file: 
-        fasta_dict = create_fasta_dict(input2_file)                
-        count = 0                
+    with open(os.path.join(path,file_name),"r") as input2_file:
+        fasta_dict = create_fasta_dict(input2_file)
+        count = 0
         for k in outfile_data:
             if len(outfile_data[k]) >= 5:
                 output_file = open(os.path.join(output_directory,str(out_name)+"-refined_%s.fna" % (k)), "w" )
@@ -207,12 +209,12 @@ def affinity_propagation(array,names,file_name,damping,iterations,convergence,pr
             if os.path.isfile(os.path.join(output_directory,'unclustered.fna')) is True:
                 contig_number = 0
                 for record in SeqIO.parse(os.path.join(output_directory,'unclustered.fna'),"fasta"):
-                        contig_number +=1
+                    contig_number +=1
                 if contig_number < 2:
-                        os.remove(os.path.join(output_directory,'unclustered.fna'))
-            print "          Cluster "+str(k)+": "+str(len(outfile_data[k]))
-        print ("""          Total Number of Bins: %i""" % count)
-                
+                    os.remove(os.path.join(output_directory,'unclustered.fna'))
+            print("          Cluster "+str(k)+": "+str(len(outfile_data[k])))
+        print(("""          Total Number of Bins: %i""" % count))
+
 class Logger(object):
     def __init__(self,logfile,location):
         self.terminal = sys.stdout
@@ -223,7 +225,7 @@ class Logger(object):
         self.log.write(message)
 
     def flush(self):
-        pass    
+        pass
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='Binsanity-refine', description="""
     ***********************************************************************
@@ -245,9 +247,9 @@ if __name__ == '__main__':
     """)
     parser.add_argument("-p", type=float, dest="preference", default=-25, help="""
     Specify a preference (default is -25)
-    Note: decreasing the preference leads to more lumping, 
+    Note: decreasing the preference leads to more lumping,
     increasing will lead to more splitting. If your range
-    of coverages are low you will want to decrease the 
+    of coverages are low you will want to decrease the
     preference, if you have 10 or less replicates increasing
     the preference could benefit you. For complex datasets
     with low abundance organisms a preference
@@ -262,7 +264,7 @@ if __name__ == '__main__':
     of estimated clusters that stops the convergence.
     """)
     parser.add_argument("-kmer",type=int,dest="inputKmer",default=4,help="""
-    Specify a number for kmer calculation. Default is 4. 
+    Specify a number for kmer calculation. Default is 4.
     Tetramer frequencies are recommended
     """)
     parser.add_argument("-d",default=0.95, type=float, dest="damp", help="""
@@ -275,7 +277,7 @@ if __name__ == '__main__':
     Specify the contig size cut-off (Default 1000 bp)
     """)
     parser.add_argument("-o",dest="outputdir", default="BINSANITY-REFINEMENT", help="""
-    Give a name to the directory BinSanity results will be output in 
+    Give a name to the directory BinSanity results will be output in
     [Default is 'BINSANITY-REFINEMENT']
     """)
     parser.add_argument("--log",dest="LogFile",default="binsanity-refine.log",help="""
@@ -286,23 +288,23 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     if len(sys.argv)<3:
-        parser.print_help()    
+        parser.print_help()
     if args.inputCovFile is None:
         if (args.inputContigFiles is None) and (args.fastafile is None):
             parser.print_help()
     if (args.inputCovFile is None):
-        print "Please indicate -c coverage file"
+        print("Please indicate -c coverage file")
     if args.inputContigFiles is None:
-        print "Please indicate -f directory containing your contigs"
+        print("Please indicate -f directory containing your contigs")
     elif args.inputContigFiles and not args.fastafile:
         parser.error('-l Need to identify file to be clustered')
 
     else:
         start_time = time.time()
         if os.path.isdir(str(args.outputdir)) is False:
-        	os.mkdir(args.outputdir)
+            os.mkdir(args.outputdir)
         sys.stdout = Logger(args.LogFile,args.outputdir)
-        print """
+        print("""
         ******************************************************
         **********************BinSanity***********************
         |____________________________________________________|
@@ -310,49 +312,49 @@ if __name__ == '__main__':
         |                                                    |
         |              Calculating GC content                |
         |____________________________________________________|
-        """
+        """)
         GC_time = time.time()
         GC_Fasta_file(args.inputContigFiles, args.fastafile,args.outputdir)
-        print "          GC content calculated in %s seconds" % (time.time() - GC_time)
-        print """
+        print("          GC content calculated in %s seconds" % (time.time() - GC_time))
+        print("""
          ______________________________________________________
 
                      Calculating %smer frequencies
-         ______________________________________________________"""% str(args.inputKmer)        
+         ______________________________________________________"""% str(args.inputKmer))
         kmer_time = time.time()
         output(kmer_counts(args.inputKmer,args.inputContigFiles,args.fastafile),args.outputdir,args.inputKmer)
-        print "           %smer frequency calculated in %s seconds" % (args.inputKmer,time.time()- kmer_time)
-        print """
+        print("           %smer frequency calculated in %s seconds" % (args.inputKmer,time.time()- kmer_time))
+        print("""
         ______________________________________________________
 
                    Creating Combined Profile
-        ______________________________________________________"""         
+        ______________________________________________________""")
         combine_time = time.time()
-        print "            Combined profile created in %s seconds" % (time.time()- combine_time)
-       
+        print("            Combined profile created in %s seconds" % (time.time()- combine_time))
+
         get_contigs(args.inputCovFile,args.outputdir,args.inputKmer)
-        print """
+        print("""
         ______________________________________________________
 
          Clustering Using %smers, GC percentage, and Coverage
-        ______________________________________________________"""%(args.inputKmer)
-        print "          Preference: " + str(args.preference)
-        print "          Maximum Iterations: " + str(args.maxiter)
-        print "          Convergence Iterations: " + str(args.conviter)
-        print "          Contig Cut-Off: " + str(args.ContigSize)
-        print "          Damping Factor: " + str(args.damp)
-        print "          Coverage File: " + str(args.inputCovFile)
-        print "          Fasta File: " + str(args.fastafile)
+        ______________________________________________________"""%(args.inputKmer))
+        print("          Preference: " + str(args.preference))
+        print("          Maximum Iterations: " + str(args.maxiter))
+        print("          Convergence Iterations: " + str(args.conviter))
+        print("          Contig Cut-Off: " + str(args.ContigSize))
+        print("          Damping Factor: " + str(args.damp))
+        print("          Coverage File: " + str(args.inputCovFile))
+        print("          Fasta File: " + str(args.fastafile))
 
         val1, val2 = cov_array((get_cov_data(os.path.join(args.outputdir,'kmer-GC-out.txt'))), args.inputContigFiles, args.fastafile,args.ContigSize)
- 
+
         affinity_propagation(val1, val2, args.fastafile, args.damp, args.maxiter, args.conviter, args.preference,args.inputContigFiles,args.outputdir,args.outname)
-  
-        print("""
+
+        print(("""
         ______________________________________________________
-                   Bins Computed in 
+                   Bins Computed in
                    %s seconds
-        ______________________________________________________""" % (time.time() - start_time))
-	for f in os.listdir(args.outputdir):
-		if f.endswith(".txt"):
-			os.remove(os.path.join(args.outputdir,f))
+        ______________________________________________________""" % (time.time() - start_time)))
+        for f in os.listdir(args.outputdir):
+            if f.endswith(".txt"):
+                os.remove(os.path.join(args.outputdir,f))

--- a/bin/Binsanity-wf
+++ b/bin/Binsanity-wf
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-
+from __future__ import print_function, division
 
 from argparse import RawTextHelpFormatter
 import glob,os, sys, time, argparse,shutil,re,csv
@@ -50,7 +50,7 @@ def cov_array(a,path,file_name,size):
     for record in SeqIO.parse(os.path.join(path, file_name), "fasta"):
         count = count + 1
         if len(record.seq) >= int(size):
-            if record.id in a.keys():
+            if record.id in a:
                 data = a[record.id]
                 names.append(data[0])
                 data.remove(data[0])
@@ -60,9 +60,9 @@ def cov_array(a,path,file_name,size):
                     cov_array = np.vstack((cov_array, temparray))
                 if c == 0:
                     cov_array = np.fromstring(line, dtype=float, sep=' ')
-                    c += 1 
-    print("          %s" % (cov_array.shape,))
-    return cov_array, names  
+                    c += 1
+    print(("          %s" % (cov_array.shape,)))
+    return cov_array, names
 
 def affinity_propagation(array,names,file_name,damping,iterations,convergence,preference,path,output_directory,binname):
     """Uses affinity propagation to make putative bins"""
@@ -70,20 +70,20 @@ def affinity_propagation(array,names,file_name,damping,iterations,convergence,pr
     outfile_data = {}
     i = 0
     while i < len(names):
-        if apclust[i] in outfile_data.keys():
+        if apclust[i] in outfile_data:
             outfile_data[apclust[i]].append(names[i])
-        if apclust[i] not in outfile_data.keys():
+        if apclust[i] not in outfile_data:
             outfile_data[apclust[i]] = [names[i]]
         i += 1
     if binname is None:
-    	out_name = file_name.rsplit(".",1)[0]+"_Bin"
+        out_name = file_name.rsplit(".",1)[0]+"_Bin"
     else:
-    	out_name = binname+"_Bin"
+        out_name = binname+"_Bin"
     output_directory=output_directory+"/BINSANITY-INITIAL"
     os.mkdir(output_directory)
-    with open(os.path.join(path,file_name),"r") as input2_file: 
-        fasta_dict = create_fasta_dict(input2_file)                
-        count = 0                
+    with open(os.path.join(path,file_name),"r") as input2_file:
+        fasta_dict = create_fasta_dict(input2_file)
+        count = 0
         for k in outfile_data:
             if len(outfile_data[k]) >= 5:
                 output_file = open(os.path.join(output_directory,str(out_name)+"-%s.fna" % (k)), "w")
@@ -106,34 +106,34 @@ def affinity_propagation(array,names,file_name,damping,iterations,convergence,pr
             if os.path.isfile(os.path.join(output_directory,'unclustered.fna')) is True:
                 contig_number = 0
                 for record in SeqIO.parse(os.path.join(output_directory,'unclustered.fna'),"fasta"):
-                        contig_number +=1
+                    contig_number +=1
                 if contig_number < 2:
-                        os.remove(os.path.join(output_directory,'unclustered.fna'))
-            print("          Cluster "+str(k)+": "+str(len(outfile_data[k])))
-        print("""          Total Number of Bins: %i""" % count)
-    
+                    os.remove(os.path.join(output_directory,'unclustered.fna'))
+            print(("          Cluster "+str(k)+": "+str(len(outfile_data[k]))))
+        print(("""          Total Number of Bins: %i""" % count))
+
 def GC_Fasta_file(b,name,prefix,location):
     """Makes a tab-delimeted output indicating the GC count associated with each contig"""
     GC_dict = {}
-    input_file = open(os.path.join(b,name), 'r') 
+    input_file = open(os.path.join(b,name), 'r')
     output_file = open(os.path.join(location,str(prefix)+'-GC.txt'),'w')
     output_file.write("%s\t%s\n" % ('contig','GC'))
     for cur_record in SeqIO.parse(input_file, "fasta") :
-        gene_name = cur_record.id 
+        gene_name = cur_record.id
         GC_percent = float(GC(cur_record.seq))
         GC_dict.setdefault(gene_name,[])
-        GC_dict[gene_name].append(GC_percent) 
+        GC_dict[gene_name].append(GC_percent)
         output_line = '%s\t%i\n' % \
-        (gene_name, GC_percent) 
-        output_file.write(output_line)    
-    output_file.close() 
+        (gene_name, GC_percent)
+        output_file.write(output_line)
+    output_file.close()
     input_file.close()
 ###########################Get tetramer frequencies#####################################
 
 def kmer_list(dna, k):
     """Makes list of k-mers based on input of k and the dna sequence"""
     result = []
-    dna = dna.upper()	
+    dna = dna.upper()
     dna_edit = Seq(str(dna),IUPAC.unambiguous_dna)
     reverse_complement = (dna_edit).reverse_complement()
     dna_edit = str(dna_edit)
@@ -151,7 +151,7 @@ def kmer_counts(kmer,b,name):
         id_=record.id
         seq = record.seq
         length = len(seq)
-        tetra = kmer_list(seq,kmer)           
+        tetra = kmer_list(seq,kmer)
         c = collections.Counter(tetra)
         c = dict(c)
         val = list(c.values())
@@ -159,21 +159,21 @@ def kmer_counts(kmer,b,name):
         for freq in val:
             freq= (float(freq)/float(length))
             val_edit.append(freq)
-    
+
         keys = []
         for key in c:
             keys.append(str(key))
-        c_edit = dict(zip(keys,val_edit))
+        c_edit = dict(list(zip(keys,val_edit)))
         kmer_dict.setdefault(str(id_),[])
         kmer_dict[str(id_)].append(c_edit)
     return kmer_dict
-                   
-         
+
+
 def output(a,prefix,kmer,location):
     """Builds tab-delimeted file based on dictionary of tetramers"""
-    topleft = 'contig' 
+    topleft = 'contig'
     headers = sorted(set(key
-                        for row in a.values()
+                        for row in list(a.values())
                         for key in row[0]))
     name = str(kmer)
     writer = csv.writer(open(os.path.join(location,str(prefix)+'-%smerFrequencies.txt'%(name)),'wb'), delimiter='\t')
@@ -204,7 +204,7 @@ def get_contigs(c,prefix,kmer,location):
     result.to_csv(path_or_buf=str(os.path.join(location,str(prefix)+"-kmerGC.txt")),header=None,sep ="\t")
 
 def refined_ap(array,names,file_name,damping,iterations,convergence,preference,path,output_directory):
-    """Uses affinity propagation to make putative bins"""    
+    """Uses affinity propagation to make putative bins"""
     if os.path.isdir(os.path.join(str(output_directory),"REFINED-BINS")) is False:
         os.mkdir(os.path.join(str(output_directory),"REFINED-BINS"))
     name_of_output_file = os.path.join(str(output_directory),"REFINED-BINS")
@@ -212,15 +212,15 @@ def refined_ap(array,names,file_name,damping,iterations,convergence,preference,p
     outfile_data = {}
     i = 0
     while i < len(names):
-        if apclust[i] in outfile_data.keys():
+        if apclust[i] in outfile_data:
             outfile_data[apclust[i]].append(names[i])
-        if apclust[i] not in outfile_data.keys():
+        if apclust[i] not in outfile_data:
             outfile_data[apclust[i]] = [names[i]]
         i += 1
     out_name = file_name.rsplit(".",1)[0]
-    with open(os.path.join(path,file_name),"r") as input2_file: 
-        fasta_dict = create_fasta_dict(input2_file)                
-        count = 0                
+    with open(os.path.join(path,file_name),"r") as input2_file:
+        fasta_dict = create_fasta_dict(input2_file)
+        count = 0
         for k in outfile_data:
             if len(outfile_data[k]) >= 5:
                 output_file = open(os.path.join(name_of_output_file,str(out_name)+"-refined_%s.fna" % (k)), "w" )
@@ -243,15 +243,15 @@ def refined_ap(array,names,file_name,damping,iterations,convergence,preference,p
             if os.path.isfile(os.path.join(output_directory,'unclustered.fna')) is True:
                 contig_number = 0
                 for record in SeqIO.parse(os.path.join(output_directory,'unclustered.fna'),"fasta"):
-                        contig_number +=1
+                    contig_number +=1
                 if contig_number < 2:
-                        os.remove(os.path.join(output_directory,'unclustered.fna'))
-            print("Cluster "+str(k)+": "+str(len(outfile_data[k])))
-        print("""Total Number of Bins: %i""" % count)
-    
+                    os.remove(os.path.join(output_directory,'unclustered.fna'))
+            print(("Cluster "+str(k)+": "+str(len(outfile_data[k]))))
+        print(("""Total Number of Bins: %i""" % count))
+
 ########################################################################################
 def run_checkM(bins,threads,prefix,directory):
-    output = open(os.path.join(directory,str(prefix)+"_checkm_lineagewf-results.txt"),"w")   
+    output = open(os.path.join(directory,str(prefix)+"_checkm_lineagewf-results.txt"),"w")
     subprocess.call(["checkm","lineage_wf","-x","fna","-t",str(threads),str(bins),os.path.join(directory,str(prefix)+"_binsanity_checkm")],stdout=output)
 ########################################################################################
 def checkm_analysis(file_,fasta,path):
@@ -261,7 +261,7 @@ def checkm_analysis(file_,fasta,path):
         for string in list_:
             x = re.sub(' +',' ',str(re.split(r'\t+', string.rstrip('\t'))))
             new.append(x)
-    
+
     del new[0], new[1], new[(len(new)-1)]
     new_2 = []
     for list_ in new:
@@ -293,7 +293,7 @@ def checkm_analysis(file_,fasta,path):
     os.makedirs(os.path.join(path,"low_completion"))
     os.makedirs(os.path.join(path,"high_redundancy"))
     os.makedirs(os.path.join(path,"strain_redundancy"))
-    
+
     for name in High_completion:
         shutil.move(os.path.join(path,(str(name)+fasta)), os.path.join(path,"high_completion"))
     for name in Low_completion:
@@ -302,14 +302,14 @@ def checkm_analysis(file_,fasta,path):
         shutil.move(os.path.join(path,(str(name)+fasta)),os.path.join(path,"high_redundancy"))
     for name in Strain_variation:
         shutil.move(os.path.join(path,(str(name)+fasta)),os.path.join(path,"strain_redundancy"))
-########################################################################################     
+########################################################################################
 class Logger(object):
     def __init__(self,logfile,location):
         self.terminal = sys.stdout
         if logfile is None:
-        	self.log = open(os.path.join(location,"Binsanity-wf.log"), "a")
-	else:
-		self.log = open(os.path.join(location,logfile+".log"), "a")
+            self.log = open(os.path.join(location,"Binsanity-wf.log"), "a")
+        else:
+            self.log = open(os.path.join(location,logfile+".log"), "a")
     def write(self, message):
         self.terminal.write(message)
         self.log.write(message)
@@ -323,21 +323,21 @@ if __name__ == '__main__':
     ************************************************************************************************
     **************************************BinSanity*************************************************
     **  Binsanity-wf is a workflow script that runs Binsanity and Binsanity-refine sequentially.  **
-    **  The following is including in the workflow:                                               ** 
+    **  The following is including in the workflow:                                               **
     **  STEP 1. Run Binsanity                                                                     **
-    **  STEP 2: Run CheckM to estimate completeness for Refinement                                ** 
+    **  STEP 2: Run CheckM to estimate completeness for Refinement                                **
     **  STEP 3: Run Binsanity-refine                                                              **
     **  STEP 4: Create Final BinSanity Clusters                                                   **
-    **                                                                                            **  
+    **                                                                                            **
     ************************************************************************************************
-    """,formatter_class=RawTextHelpFormatter)     
+    """,formatter_class=RawTextHelpFormatter)
     parser.add_argument("-c", dest="inputCovFile", help="""
     Specify a Transformed Coverage File
     e.g Log transformed
     """)
     parser.add_argument("-f", dest="inputContigFiles",metavar="FastaLocation", help="""Specify directory containing your contigs""")
     parser.add_argument("-p", type=float, dest="preference", default=-3, help="""Specify a preference [Default: -3]
-    Note: decreasing the preference leads to more lumping, 
+    Note: decreasing the preference leads to more lumping,
     increasing will lead to more splitting. If your range
     of coverages are low you will want to decrease the
     preference, if you have 10 or less replicates increasing
@@ -345,12 +345,12 @@ if __name__ == '__main__':
     parser.add_argument("-m", type=int, dest="maxiter", default=4000, help="""
     Specify a max number of iterations [Default: 4000]""")
     parser.add_argument("-v", type=int, dest="conviter",metavar="ConvergenceIteration",default=400, help="""Specify the convergence iteration number [Default: 400]
-    e.g Number of iterations with no change in the number 
+    e.g Number of iterations with no change in the number
     of estimated clusters that stops the convergence.""")
     parser.add_argument("-d",default=0.95, type=float, dest="damp",metavar="DampeningFactor", help="""Specify a damping factor between 0.5 and 1, [Default: 0.95]""")
     parser.add_argument("-l",dest="fastafile",metavar="FastaFile", help="""Specify the fasta file containing contigs you want to cluster""")
     parser.add_argument("-x",dest="ContigSize", type=int,metavar="SizeThreshold", default=1000,help="""Specify the contig size cut-off [Default: 1000 bp]""")
-    parser.add_argument("-o",dest="outputdir", default="BINSANITY-RESULTS", metavar="OutputDirectory", help="""Give a name to the directory BinSanity results will be output in 
+    parser.add_argument("-o",dest="outputdir", default="BINSANITY-RESULTS", metavar="OutputDirectory", help="""Give a name to the directory BinSanity results will be output in
     [Default: 'BINSANITY-RESULTS']""")
     parser.add_argument("--threads",dest="threads",type=int,default=1, help="""Indicate how many threads you want dedicated to the subprocess CheckM. [Default=1]""")
     parser.add_argument("--kmer",dest="kmer",type=int,default=4,help="""Indicate a number for the kmer calculation, the [Default: 4]""")
@@ -362,7 +362,7 @@ if __name__ == '__main__':
     if len(sys.argv) is None:
         parser.print_help()
     if os.path.isfile("high_completion"):
-        print("File name 'high_completion' already exists and Binsanity does not like overwritting files")      
+        print("File name 'high_completion' already exists and Binsanity does not like overwritting files")
     if os.path.isfile("low_completion"):
         print("File name 'low_completion' already exists and Binsanity does not like overwritting files")
     if os.path.isfile("high_redundancy"):
@@ -381,61 +381,61 @@ if __name__ == '__main__':
         start_time = time.time()
 
         if os.path.isdir(str(args.outputdir)) is False:
-        	os.mkdir(args.outputdir)
+            os.mkdir(args.outputdir)
         sys.stdout = Logger(args.prefix,args.outputdir)
         print("""
         ******************************************************
         **********************BinSanity***********************
         |____________________________________________________|
-        |                                                    | 
-        |             Computing Coverage Array               | 
+        |                                                    |
+        |             Computing Coverage Array               |
         |____________________________________________________|
         """)
-        print("          Preference: " + str(args.preference))
-        print("          Maximum Iterations: " + str(args.maxiter))
-        print("          Convergence Iterations: " + str(args.conviter))
-        print("          Contig Cut-Off: " + str(args.ContigSize))
-        print("          Damping Factor: " + str(args.damp))
-        print("          Coverage File: " + str(args.inputCovFile))
-        print("          Fasta File: " + str(args.fastafile))
-        print("          Output Directory: " + str(args.outputdir))
-	try:        
-        	val1, val2 = cov_array((get_cov_data(args.inputCovFile)), args.inputContigFiles, args.fastafile,args.ContigSize)
-	except:
-                print("The program failed to read in your coverage file :(. Please check it to make sure it is in the right format.")
-                with open("error_code.txt","w") as out_file:
-                        out_file.write("1")
-                sys.exit(1)	
+        print(("          Preference: " + str(args.preference)))
+        print(("          Maximum Iterations: " + str(args.maxiter)))
+        print(("          Convergence Iterations: " + str(args.conviter)))
+        print(("          Contig Cut-Off: " + str(args.ContigSize)))
+        print(("          Damping Factor: " + str(args.damp)))
+        print(("          Coverage File: " + str(args.inputCovFile)))
+        print(("          Fasta File: " + str(args.fastafile)))
+        print(("          Output Directory: " + str(args.outputdir)))
+        try:
+            val1, val2 = cov_array((get_cov_data(args.inputCovFile)), args.inputContigFiles, args.fastafile,args.ContigSize)
+        except:
+            print("The program failed to read in your coverage file :(. Please check it to make sure it is in the right format.")
+            with open("error_code.txt","w") as out_file:
+                out_file.write("1")
+            sys.exit(1)
         print("""
-         ______________________________________________________   
+         ______________________________________________________
         |                                                      |
         |                 Clustering Contigs                   |
         |______________________________________________________|
-        
-        """) 
-	try:
-        	affinity_propagation(val1,val2,args.fastafile,args.damp,args.maxiter,args.conviter,args.preference,args.inputContigFiles,args.outputdir,args.binprefix)
+
+        """)
+        try:
+            affinity_propagation(val1,val2,args.fastafile,args.damp,args.maxiter,args.conviter,args.preference,args.inputContigFiles,args.outputdir,args.binprefix)
         except:
-		print("Binsanity failed to complete clustering with affinity propagation. The most likely situation in which Binsanity fails here is a memory issue :(. You can eitehr try allocating more memory on your machine or try running Binsanity-lc" )
-                with open("error_code.txt","w") as out_file:
-                        out_file.write("2")
-		sys.exit(1)
-	print("""
+            print("Binsanity failed to complete clustering with affinity propagation. The most likely situation in which Binsanity fails here is a memory issue :(. You can eitehr try allocating more memory on your machine or try running Binsanity-lc" )
+            with open("error_code.txt","w") as out_file:
+                out_file.write("2")
+            sys.exit(1)
+        print("""
          *|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*
          _____________________________________________________
         |                                                     |
         |                   Creating Bins                     |
         |_____________________________________________________|
-        """)  
+        """)
 
-        print("""
+        print(("""
          _____________________________________________________
-                                                               
-                       Putative Bins Computed                 
-                       in %s seconds                          
-         _____________________________________________________""" % (time.time() - start_time))
+
+                       Putative Bins Computed
+                       in %s seconds
+         _____________________________________________________""" % (time.time() - start_time)))
 ##########################Finding Bin Metrics####################################
-    
+
         print("""
          _____________________________________________________
         |                                                     |
@@ -443,129 +443,129 @@ if __name__ == '__main__':
         |_____________________________________________________|
         """)
         out_1= args.outputdir+'/BINSANITY-INITIAL'
-	try:
-        	run_checkM(str(out_1),str(args.threads),args.prefix,args.outputdir)
+        try:
+            run_checkM(str(out_1),str(args.threads),args.prefix,args.outputdir)
         except:
-                print("Binsanity failed to run CheckM. In all liklihood there is an issue with your CheckM installation.")
-                with open("error_code.txt","w") as out_file:
-                        out_file.write("3")
-                sys.exit(1)
-	checkm_analysis(os.path.join(args.outputdir,str(args.prefix)+"_checkm_lineagewf-results.txt"),".fna",str(out_1))
+            print("Binsanity failed to run CheckM. In all liklihood there is an issue with your CheckM installation.")
+            with open("error_code.txt","w") as out_file:
+                out_file.write("3")
+            sys.exit(1)
+        checkm_analysis(os.path.join(args.outputdir,str(args.prefix)+"_checkm_lineagewf-results.txt"),".fna",str(out_1))
 ##############################Refining Bins#######################################
         start_time = time.time()
         location = os.path.join(out_1,"high_redundancy")
         location2 = os.path.join(out_1,"low_completion")
-	location4 =  os.path.join(out_1,"high_completion")
+        location4 =  os.path.join(out_1,"high_completion")
         if len(os.listdir(location2)) != 0:
-                with open("low_completion.fna","wb") as outfile:
-                    for filename in glob.glob(str(location2)+"/*.fna"):
-                        if filename == "low_completion.fna":
-                            continue
-                        else:
-                            with open(filename,"rb") as readfile:
-                                shutil.copyfileobj(readfile,outfile)
-        
-        	shutil.move("low_completion.fna", str(location))
-        	shutil.rmtree(str(location2))
-	location3 = os.path.join(out_1,"strain_redundancy")
-	if len(os.listdir(location3)) != 0:
-        	for filename in glob.glob(str(location3)+"/*.fna"):
-                	shutil.move(filename, str(location4))
-	print("""
+            with open("low_completion.fna","wb") as outfile:
+                for filename in glob.glob(str(location2)+"/*.fna"):
+                    if filename == "low_completion.fna":
+                        continue
+                    else:
+                        with open(filename,"rb") as readfile:
+                            shutil.copyfileobj(readfile,outfile)
+
+            shutil.move("low_completion.fna", str(location))
+            shutil.rmtree(str(location2))
+        location3 = os.path.join(out_1,"strain_redundancy")
+        if len(os.listdir(location3)) != 0:
+            for filename in glob.glob(str(location3)+"/*.fna"):
+                shutil.move(filename, str(location4))
+        print("""
         *|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*|*
-    	 _____________________________________________________
-    	|                                                     |
-    	|                Refining Inital Bins                 |
-    	|_____________________________________________________|""")
-	if len(os.listdir(location)) != 0:
-		for redundant_bin in os.listdir(location):
-        	    print("""
-        	     ______________________________________________________
-        	                                                           
-        	                  Calculating GC content for               
-        	                  redundant bin %s                    
-        	     ______________________________________________________""") % str(redundant_bin)
-        	    GC_time = time.time()
-        	    GC_Fasta_file(location, redundant_bin,args.prefix,args.outputdir)
-        	    print "          GC content calculated in %s seconds" % (time.time() - GC_time)
-        	    
-        	    print("""
-        	     ______________________________________________________
-        	                                                           
-        	               Calculating %smer frequencies for              
-        	               redundant bin %s                            
-        	     ______________________________________________________""")% (args.kmer,str(redundant_bin))
-        	    kmer_time = time.time()
-       	    	    output(kmer_counts(args.kmer,location,redundant_bin),args.prefix,args.kmer,args.outputdir)
-            	    print("          %smer frequency calculated in %s seconds" % (args.kmer,time.time()- kmer_time))
-         
-            	    print("""
-            	    ______________________________________________________
-                                                                  
-                    	      Creating Profile for                     
-                        	  redundant bin %s                         
-            	    ______________________________________________________""")% str(redundant_bin)
-            	    combine_time = time.time()
-		    try:
-            	    	get_contigs(args.inputCovFile,args.prefix,args.kmer,args.outputdir)
-            	    except:
-			print("Binsanity failed while building the combined composition and coverage profile :(")
-			sys.exit(1)
-		    print("          Combined profile created in %s seconds" % (time.time()- combine_time))
-            	    refine_time=time.time()
-  	    	    print(""" 
-             	     ______________________________________________________ 
-	                                                           
-               		Reclustering redundant bin %s                       
-             	     ______________________________________________________""")% str(redundant_bin)
-           	    print("          Preference: " + str(args.inputrefinedpref))
-            	    print("          Maximum Iterations: " + str(args.maxiter))
-            	    print("          Convergence Iterations: " + str(args.conviter))
-            	    print("          Contig Cut-Off: " + str(args.ContigSize))
-            	    print("          Damping Factor: " + str(args.damp))
-            	    print("          Coverage File: " + str(args.inputCovFile))
-            	    print("          Fasta File: " + str(redundant_bin))
-            	    print("          Kmer: " + str(args.kmer))
-		    try:    
-			GC_kmer = (get_cov_data(os.path.join(args.outputdir,str(args.prefix)+'-kmerGC.txt')))
-   	            	val1, val2 = cov_array(GC_kmer, location, redundant_bin,args.ContigSize)
-    		    except:
-		    	print("Cannot find the %s-kmerGC.txt composition file.")%str(args.prefix)
-			sys.exit(1)
-		    try:	
-            	    	refined_ap(val1, val2, redundant_bin, args.damp, args.maxiter, args.conviter, args.inputrefinedpref,location,args.outputdir)
-                    except:
-                     	print("BinSanity failed when refining you genomes :/. The Bin that it failed at was the following bin: %s")%str(redundant_bin)
-		     	with open("error_code.txt","w") as out_file:
-                        	out_file.write("4")
-                        	out_file.write("%s")%str(redundant_bin)
-			sys.exit(1)
-   	            print("""
-             	      ______________________________________________________
-                                                                   
-              			Ammended Bins Computed in %s seconds                 
-            	      ______________________________________________________""" % (time.time() - refine_time))
+         _____________________________________________________
+        |                                                     |
+        |                Refining Inital Bins                 |
+        |_____________________________________________________|""")
+        if len(os.listdir(location)) != 0:
+            for redundant_bin in os.listdir(location):
+                print(("""
+                 ______________________________________________________
+
+                              Calculating GC content for
+                              redundant bin %s
+                 ______________________________________________________""") % str(redundant_bin))
+                GC_time = time.time()
+                GC_Fasta_file(location, redundant_bin,args.prefix,args.outputdir)
+                print("          GC content calculated in %s seconds" % (time.time() - GC_time))
+
+                print(("""
+                 ______________________________________________________
+
+                           Calculating %smer frequencies for
+                           redundant bin %s
+                 ______________________________________________________""")% (args.kmer,str(redundant_bin)))
+                kmer_time = time.time()
+                output(kmer_counts(args.kmer,location,redundant_bin),args.prefix,args.kmer,args.outputdir)
+                print(("          %smer frequency calculated in %s seconds" % (args.kmer,time.time()- kmer_time)))
+
+                print(("""
+                ______________________________________________________
+
+                          Creating Profile for
+                              redundant bin %s
+                ______________________________________________________""")% str(redundant_bin))
+                combine_time = time.time()
+                try:
+                    get_contigs(args.inputCovFile,args.prefix,args.kmer,args.outputdir)
+                except:
+                    print("Binsanity failed while building the combined composition and coverage profile :(")
+                    sys.exit(1)
+                print(("          Combined profile created in %s seconds" % (time.time()- combine_time)))
+                refine_time=time.time()
+                print(("""
+                 ______________________________________________________
+
+                    Reclustering redundant bin %s
+                 ______________________________________________________""")% str(redundant_bin))
+                print(("          Preference: " + str(args.inputrefinedpref)))
+                print(("          Maximum Iterations: " + str(args.maxiter)))
+                print(("          Convergence Iterations: " + str(args.conviter)))
+                print(("          Contig Cut-Off: " + str(args.ContigSize)))
+                print(("          Damping Factor: " + str(args.damp)))
+                print(("          Coverage File: " + str(args.inputCovFile)))
+                print(("          Fasta File: " + str(redundant_bin)))
+                print(("          Kmer: " + str(args.kmer)))
+                try:
+                    GC_kmer = (get_cov_data(os.path.join(args.outputdir,str(args.prefix)+'-kmerGC.txt')))
+                    val1, val2 = cov_array(GC_kmer, location, redundant_bin,args.ContigSize)
+                except:
+                    print(("Cannot find the %s-kmerGC.txt composition file.")%str(args.prefix))
+                    sys.exit(1)
+                try:
+                    refined_ap(val1, val2, redundant_bin, args.damp, args.maxiter, args.conviter, args.inputrefinedpref,location,args.outputdir)
+                except:
+                    print(("BinSanity failed when refining you genomes :/. The Bin that it failed at was the following bin: %s")%str(redundant_bin))
+                    with open("error_code.txt","w") as out_file:
+                        out_file.write("4")
+                        out_file.write("%s")%str(redundant_bin)
+                    sys.exit(1)
+                print(("""
+                  ______________________________________________________
+
+                            Ammended Bins Computed in %s seconds
+                  ______________________________________________________""" % (time.time() - refine_time)))
         else:
-		print("All bins passed initial quality checks")
-	final_out = os.path.join(str(args.outputdir),"BinSanity-Final-bins")
+            print("All bins passed initial quality checks")
+        final_out = os.path.join(str(args.outputdir),"BinSanity-Final-bins")
         initial_out = os.path.join(str(args.outputdir),"BINSANITY-INITIAL")
         os.mkdir(str(final_out))
         os.rename(initial_out,os.path.join(str(args.outputdir),"Binsanity-records"))
-	try:
-        	shutil.move(os.path.join(str(args.outputdir),"REFINED-BINS"),os.path.join(str(args.outputdir),"Binsanity-records"))
-        except:
-		pass
-	path1 = os.path.join(args.outputdir,"Binsanity-records/high_completion")
-        for files in os.listdir(path1):
-		shutil.copy(os.path.join(os.path.join(str(args.outputdir),"Binsanity-records/high_completion"),files),str(final_out))
         try:
-		for files in os.listdir(os.path.join(str(args.outputdir),"Binsanity-records/REFINED-BINS")):
-        		shutil.copy(os.path.join(os.path.join(str(args.outputdir),"Binsanity-records/REFINED-BINS"),files),str(final_out))
-	except:
-		pass
-	shutil.move(os.path.join(args.outputdir,str(args.prefix)+"-kmerGC.txt"),os.path.join(args.outputdir,"Binsanity-records/"))
+            shutil.move(os.path.join(str(args.outputdir),"REFINED-BINS"),os.path.join(str(args.outputdir),"Binsanity-records"))
+        except:
+            pass
+        path1 = os.path.join(args.outputdir,"Binsanity-records/high_completion")
+        for files in os.listdir(path1):
+            shutil.copy(os.path.join(os.path.join(str(args.outputdir),"Binsanity-records/high_completion"),files),str(final_out))
+        try:
+            for files in os.listdir(os.path.join(str(args.outputdir),"Binsanity-records/REFINED-BINS")):
+                shutil.copy(os.path.join(os.path.join(str(args.outputdir),"Binsanity-records/REFINED-BINS"),files),str(final_out))
+        except:
+            pass
+        shutil.move(os.path.join(args.outputdir,str(args.prefix)+"-kmerGC.txt"),os.path.join(args.outputdir,"Binsanity-records/"))
         shutil.move(os.path.join(args.outputdir,str(args.prefix)+"-%smerFrequencies.txt"%(args.kmer)),os.path.join(str(args.outputdir),"Binsanity-records/"))
         shutil.move(os.path.join(args.outputdir,str(args.prefix)+"-GC.txt"),os.path.join(str(args.outputdir),"Binsanity-records/"))
         shutil.move(os.path.join(args.outputdir,str(args.prefix)+"_checkm_lineagewf-results.txt"),os.path.join(str(args.outputdir),"Binsanity-records/"))
         shutil.move(os.path.join(args.outputdir,str(args.prefix)+"_binsanity_checkm"),os.path.join(str(args.outputdir),"Binsanity-records/"))
-	make_tarfile(os.path.join(str(args.outputdir),"Binsanity-records.tar.gz"), os.path.join(str(args.outputdir),"Binsanity-records/"))
+        make_tarfile(os.path.join(str(args.outputdir),"Binsanity-records.tar.gz"), os.path.join(str(args.outputdir),"Binsanity-records/"))

--- a/utils/bin_evaluation
+++ b/utils/bin_evaluation
@@ -16,22 +16,22 @@ def bin_output(b,l):
 	for record in SeqIO.parse(os.path.join(b,filename), "fasta"):
 		contig_names_bin.append(record.id)
         else:
-            print "No file's with this Suffix exist in this directory: " , b
+            print("No file's with this Suffix exist in this directory: " , b)
                 
         
-    new_ = dict(zip(contig_names_bin, file_names))
+    new_ = dict(list(zip(contig_names_bin, file_names)))
     files_sorted = []
     od = dict(OrderedDict(sorted(new_.items())))
-    for key , value in od.iteritems():
+    for key , value in od.items():
         files_sorted.append(value)
     return files_sorted
     
 
 def ari(a,b):
-    print "_______________________________________________________________________________________"
-    print "Adjusted-Rand-Index: " , metrics.adjusted_rand_score(a,b)
-    print "Homogeneity, completeness, V-measure: " , metrics.homogeneity_completeness_v_measure(a,b)
-    print "_______________________________________________________________________________________"
+    print("_______________________________________________________________________________________")
+    print("Adjusted-Rand-Index: " , metrics.adjusted_rand_score(a,b))
+    print("Homogeneity, completeness, V-measure: " , metrics.homogeneity_completeness_v_measure(a,b))
+    print("_______________________________________________________________________________________")
            
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='bin_evaluation', usage='%(prog)s -b Putative Genomes -r reference genomes -l suffix of fasta files',description="""
@@ -58,13 +58,13 @@ if __name__ == '__main__':
     args = parser.parse_args()
     
     if args.inputPutative is None:
-        print "Need to specify directory containing putative genomes"
+        print("Need to specify directory containing putative genomes")
         parser.print_help()
     elif args.inputreference is None:
-        print "Need to specify directory containing reference genomes"
+        print("Need to specify directory containing reference genomes")
         parser.print_help()
     elif args.inputSuffix is None:
-        print "Need to specify Suffix linking putative genomes/reference genomes"
+        print("Need to specify Suffix linking putative genomes/reference genomes")
         parser.print_help()
             
     else: 

--- a/utils/bin_output
+++ b/utils/bin_output
@@ -14,7 +14,7 @@ def bin_output(b,o):
             contig_names_bin.append(record.id)
 	    file2 = filename.rsplit('.',1)[0]
             file_names.append(str(file2))
-    new_ = zip(contig_names_bin, file_names)
+    new_ = list(zip(contig_names_bin, file_names))
     with open(str(o), 'w') as file:
         file.writelines('\t'.join(i) + '\n' for i in new_)
 
@@ -31,5 +31,5 @@ if __name__ == '__main__':
     
     
     else:
-        print 
+        print() 
         bin_output(args.inputPutative,args.inputOUTPUT)

--- a/utils/checkm_analysis
+++ b/utils/checkm_analysis
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     
     if args.inputqa is None:
-        print parser.print_help()
+        print(parser.print_help())
     else:
         checkm_analysis(args.inputqa,args.inputfa)
         

--- a/utils/concat
+++ b/utils/concat
@@ -56,9 +56,9 @@ if __name__ == '__main__':
     parser.add_argument("-N",dest="number",metavar="",help="Specify the minimum number of sequences needed to be included in concatenation")	
     args = parser.parse_args()
     if len(sys.argv)<2:
-	print parser.print_help()
+	print(parser.print_help())
     elif os.path.isfile(args.inputOutFile):
-        print "Your Output File Already Exists and We don't want to overwrite it"
+        print("Your Output File Already Exists and We don't want to overwrite it")
     else:
         concat_alignments(args.inputDir,args.inputExtension,args.inputPrefix,args.inputOutFile,args.number)
         

--- a/utils/get-ids
+++ b/utils/get-ids
@@ -30,15 +30,15 @@ if __name__ == '__main__':
     parser.add_argument("-x",dest="inputLength",metavar="",type=int,help="Specify minimum length to be incorporated")
     args = parser.parse_args()
     if len(sys.argv) < 2:
-    	print parser.print_help()
+    	print(parser.print_help())
     elif args.inputPutative is None:
-        print "Identify directory where fasta file is using -f"
+        print("Identify directory where fasta file is using -f")
     elif args.inputFasta is None:
-        print "Identify fasta file is using -l"
+        print("Identify fasta file is using -l")
     elif args.inputOUTPUT is None:
-        print "Use -o to specify and output file"
+        print("Use -o to specify and output file")
     elif len(sys.argv) is None:
-        print parser.print_help()
+        print(parser.print_help())
     
     
     else:

--- a/utils/simplify-fasta
+++ b/utils/simplify-fasta
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     	parser.add_argument("-o",metavar="",dest="inputOUT",help="Specify the name for the output file")
     	args = parser.parse_args()
         if len(sys.argv) < 2:
-        	print parser.print_help()
+        	print(parser.print_help())
     	if args.inputFASTA is None and args.inputOUT is None:
 		print("You haven't specified an input or output silly")
     	elif args.inputFASTA is None:

--- a/utils/transform-coverage-profile
+++ b/utils/transform-coverage-profile
@@ -60,28 +60,28 @@ if __name__ == '__main__':
     We recommend using a log transformation for initial testing. Other transformations can be useful in cases where there is an extremely low range distribution of coverages and when coverage values are low""")
     args = parser.parse_args()
     if len(sys.argv)<2:
-    	print parser.print_help()
+    	print(parser.print_help())
     if args.inputoutput is None:
         parser.error('-o output fasta file needed')
     else:
         start_time = time.time()
-        print"""
+        print("""
         ---------------------------------------------------------------------
         Getting Coverage.....
-        """
+        """)
 
         x = str(args.inputoutput)
         if args.transform =="scale":
             get_100x_log(x,x+".x100.lognorm")
         elif args.transform == "log":
-            print "Transforming your combined covergae profile"
+            print("Transforming your combined covergae profile")
             get_log(x, x+".lognorm")
         elif args.transform =="X5":
-            print "Transforming your combined covergae profile"            
+            print("Transforming your combined covergae profile")            
             get_multiple(x,x+".x5", int(5))
         elif args.transform =="X10":
-            print "Transforming your combined covergae profile"            
+            print("Transforming your combined covergae profile")            
             get_multiple(x,x+".x10", int(10))
         elif args.transform =="SQR":
-            print "Transforming your combined covergae profile"            
+            print("Transforming your combined covergae profile")            
             get_squareroot(x, x+".sqrt")


### PR DESCRIPTION
Hi @edgraham,

I have been working on an Anvi'o driver for BinSanity but BinSanity not supporting Python 3 was a roadblock for me. So I ran `2to3` and `reindent.py` to see if there are any manual fixes necessary, hopefully, almost there were none. 

I tried to preserve Python 2 functionality as I do not know how long you would like to keep Python 2 support. There still might be some errors.

This resource was really helpful for me to see examples for both 2 and 3 support.
https://python-future.org/compatible_idioms.html

Thank you,